### PR TITLE
Fix inline command parsing

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -52,7 +52,7 @@ func parseStatus(s int) (string, string) {
 		status = "Downloading"
 	case 5:
 		icon = "▶️️"
-		status = "'Queued to seed"
+		status = "Queued to seed"
 	case 6:
 		icon = "▶️️"
 		status = "Seeding"

--- a/keyboards.go
+++ b/keyboards.go
@@ -38,7 +38,7 @@ func torrentDeleteKbd(hash string) tgbotapi.InlineKeyboardMarkup {
 	return tgbotapi.NewInlineKeyboardMarkup(
 		tgbotapi.NewInlineKeyboardRow(
 			tgbotapi.NewInlineKeyboardButtonData("Yes", "delete-yes_"+hash),
-			tgbotapi.NewInlineKeyboardButtonData("Yes(with data)", "delete-yes+data"+hash),
+			tgbotapi.NewInlineKeyboardButtonData("Yes(with data)", "delete-yes+data_"+hash),
 			tgbotapi.NewInlineKeyboardButtonData("Cancel", "delete-no_"+hash),
 		),
 	)
@@ -49,8 +49,8 @@ func torrentQueueKbd(hash string) tgbotapi.InlineKeyboardMarkup {
 		tgbotapi.NewInlineKeyboardRow(
 			tgbotapi.NewInlineKeyboardButtonData("⏫", "prior-top_"+hash),
 			tgbotapi.NewInlineKeyboardButtonData("🔼", "prior-up_"+hash),
-			tgbotapi.NewInlineKeyboardButtonData("🔽", "prior-down"+hash),
-			tgbotapi.NewInlineKeyboardButtonData("⏬", "prior-bottom"+hash),
+			tgbotapi.NewInlineKeyboardButtonData("🔽", "prior-down_"+hash),
+			tgbotapi.NewInlineKeyboardButtonData("⏬", "prior-bottom_"+hash),
 		),
 		tgbotapi.NewInlineKeyboardRow(
 			tgbotapi.NewInlineKeyboardButtonData("Cancel", "prior-no_"+hash),


### PR DESCRIPTION
## Summary
- ensure callback data always contains an underscore before the torrent hash
- fix a typo in torrent status text

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6883512c202c832eb8474605a57ee980